### PR TITLE
clean up: use only goimports with golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 SHELL 	:= /bin/bash
 BINDIR	:= bin
-PKG 		:= github.com/envoyproxy/go-control-plane
+PKG 	:= github.com/envoyproxy/go-control-plane
 
 .PHONY: build
 build:
@@ -29,10 +29,6 @@ test:
 .PHONY: cover
 cover:
 	@build/coverage.sh
-
-.PHONY: format
-format:
-	@goimports -local $(PKG) -w -l pkg
 
 .PHONY: examples
 examples:

--- a/build/do_ci.sh
+++ b/build/do_ci.sh
@@ -6,15 +6,7 @@ set -x
 # Needed to avoid issues with go version stamping in CI build
 git config --global --add safe.directory /go-control-plane
 
-go install golang.org/x/tools/cmd/goimports@latest
-
 cd /go-control-plane
-
-NUM_DIFF_LINES=`/go/bin/goimports -local github.com/envoyproxy/go-control-plane -d pkg | wc -l`
-if [[ $NUM_DIFF_LINES > 0 ]]; then
-  echo "Failed format check. Run make format"
-  exit 1
-fi
 
 make build
 make bin/example


### PR DESCRIPTION
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>